### PR TITLE
Fix typo in container registry domain

### DIFF
--- a/keyword-matcher-go/docker-compose.yml
+++ b/keyword-matcher-go/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   nats-news-keyword-matcher-go:
-    image: ghrc.io/heussd/nats-news-keyword-matcher-go:main
+    image: ghcr.io/heussd/nats-news-keyword-matcher-go:main
     build: .
     volumes:
       - type: bind

--- a/keyword-matcher-python/docker-compose.yml
+++ b/keyword-matcher-python/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   nats-news-keyword-matcher-python:
-    image: ghrc.io/heussd/nats-news-keyword-matcher-python
+    image: ghcr.io/heussd/nats-news-keyword-matcher-python
     build: .
     volumes:
       - type: bind

--- a/rss-article-url-feeder-go/docker-compose.yml
+++ b/rss-article-url-feeder-go/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   rss-article-url-feeder-go:
-    image: ghrc.io/heussd/rss-article-url-feeder-go:main
+    image: ghcr.io/heussd/rss-article-url-feeder-go:main
     build: .
     volumes:
       - type: bind


### PR DESCRIPTION
Hi `heussd/nats-news-analysis`!

This is not an automatic, 🤖-generated PR, as you can check in my [GitHub profile](https://github.com/p-), I work for GitHub and I am part of the [GitHub Security Lab](https://securitylab.github.com/).

While performing a code search for container registry domains we noticed that this repo contains a misspelled domain name.

If a malicious actor were in control of that misspelled domain, they could potentially perform an attack on the software supply chain of this project and/or steal the credentials used to connect to the container registry (depending on how the misspelled domain name of the container registry is used).
Please fix this typo and check your documentation for similar typos.